### PR TITLE
feat: add support for fetching navbar items from Sanity

### DIFF
--- a/lib/utils/cms.data-fetching.ts
+++ b/lib/utils/cms.data-fetching.ts
@@ -1,24 +1,30 @@
+import { NavbarItems, Projects } from '@/sanity/schemas';
 import imageUrlBuilder from '@sanity/image-url';
 import { createClient } from 'next-sanity';
 
+// Set up the client and imageBuilder to fetch data from Sanity
 const client = createClient({
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
   useCdn: process.env.NODE_ENV === 'production',
   apiVersion: 'v2024-03-02',
 });
-
 const imageBuilder = imageUrlBuilder(client);
 
+// Utils function to convert data
 export function getImageUrl(source: string) {
   let imageUrl = imageBuilder.image(source);
-  console.log("imageUrl", imageUrl.url());
+  console.log('imageUrl', imageUrl.url());
   return imageUrl.url();
 }
 
-export async function fetchProjects() {
-  const projects = await client.fetch(`*[_type == "projects"]`);
-  return projects;
+// Functions to fetch data from Sanity
+export async function fetchProjects(): Promise<Projects> {
+  return await client.fetch(`*[_type == "projects"]`);
+}
+
+export async function fetchNavbarItems(): Promise<NavbarItems> {
+  return await client.fetch(`*[_type == "navbarItems"] | order(index asc)`);
 }
 
 export default client;

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -1,6 +1,6 @@
 import { type SchemaTypeDefinition } from 'sanity';
-import { projects } from './schemas';
+import { projects, navbarItems } from './schemas';
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [projects],
+  types: [projects, navbarItems],
 };

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,1 +1,2 @@
 export * from './projects';
+export * from './navbar';

--- a/sanity/schemas/navbar.ts
+++ b/sanity/schemas/navbar.ts
@@ -1,0 +1,43 @@
+import { defineField } from 'sanity';
+import { PanelLeft } from 'lucide-react';
+
+export type NavbarItem = {
+  label: string;
+  href: string;
+};
+
+export type NavbarItems = NavbarItem[];
+
+export const navbarItems = {
+  name: 'navbarItems',
+  title: 'Navbar Items',
+  type: 'document',
+  icon: PanelLeft,
+  fields: [
+    defineField({
+      name: 'label',
+      title: 'Label',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'href',
+      title: 'Href',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'index',
+      title: 'Index',
+      type: 'number',
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Order',
+      name: 'order',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+};

--- a/sanity/schemas/projects.ts
+++ b/sanity/schemas/projects.ts
@@ -1,17 +1,7 @@
-// schemas/profile.ts
-
 import { defineField } from 'sanity';
 import { FolderOpenDotIcon } from 'lucide-react';
 
-type SanityImage = {
-  asset: {
-    _ref: string;
-    _type: string;
-  };
-  alt: string;
-};
-
-export type SanityProject = {
+export type Project = {
   title: string;
   description: string;
   image: string;
@@ -20,7 +10,7 @@ export type SanityProject = {
   tags: string[];
 };
 
-export type SanityProjects = SanityProject[];
+export type Projects = Project[];
 
 export const projects = {
   name: 'projects',
@@ -73,4 +63,3 @@ export const projects = {
     }),
   ],
 };
-


### PR DESCRIPTION
The code now includes the following changes:
- Added import for `NavbarItems` and `Projects` from `@/sanity/schemas`
- Updated `fetchNavbarItems` function to fetch navbar items from Sanity
- Added `navbarItems` schema definition for navbar items
- Updated `schema` definition to include `navbarItems`
- Removed unused code and imports related to `SanityProject` and `SanityProjects`

These changes were made to enhance the functionality of the application by allowing the fetching of navbar items from Sanity. This will enable dynamic rendering of the navbar based on the data fetched from Sanity.